### PR TITLE
Like a bug in default source URI

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var DEFAULT_SOURCE = exports.DEFAULT_SOURCE = '"https://github.com/DigixGlobal/doxity-gatsby-starter-project/archive/37f63a26c2664c31f4463a49af939ddb6e2181e7.tar.gz';
+var DEFAULT_SOURCE = exports.DEFAULT_SOURCE = 'https://github.com/DigixGlobal/doxity-gatsby-starter-project/archive/37f63a26c2664c31f4463a49af939ddb6e2181e7.tar.gz';
 var DOXITYRC_FILE = exports.DOXITYRC_FILE = '.doxityrc';
 var DEFAULT_TARGET = exports.DEFAULT_TARGET = 'scripts/doxity';
 var DEFAULT_PAGES_DIR = exports.DEFAULT_PAGES_DIR = 'pages/docs';


### PR DESCRIPTION
```
$ doxity init
.doxityrc not found or unreadable
Getting "https://github.com/DigixGlobal/doxity-gatsby-starter-project/archive/37f63a26c2664c31f4463a49af
939ddb6e2181e7.tar.gz...
(node:13630) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: Invalid URI "%22https://github.com/DigixGlobal/doxity-gatsby-starter-project/archive/37f63a26c2664c31f4463a49af939ddb6e2181e7.tar.gz"
(node:13630) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
