### PR TITLE
fixed some windows compatibility issues

### DIFF
--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -5,7 +5,7 @@ import glob from 'glob';
 import toml from 'toml';
 import tomlify from 'tomlify-j0.4';
 
-import { CONFIG_FILE, README_FILE, README_TARGET, DOXITYRC_FILE } from '../constants';
+import { CONFIG_FILE, README_FILE, README_TARGET, DOXITYRC_FILE, DEFAULT_PAGES_DIR, DEFAULT_SRC_DIR } from '../constants';
 
 import solc from './solc';
 import parseAbi from './parse-abi';
@@ -31,7 +31,7 @@ function compile({ whitelist, contracts, output, target, version }) {
     // let address;
     // if (interaction) {
     //   try {
-    //     const instance = require(`${process.env.PWD}/build/contracts/${contractName}.sol.js`);
+    //     const instance = require(`${process.cwd()}/build/contracts/${contractName}.sol.js`);
     //     address = instance.all_networks[interaction.network].address;
     //   } catch (e) { /* do noithing */ }
     // }
@@ -40,7 +40,7 @@ function compile({ whitelist, contracts, output, target, version }) {
     const data = {
       author,
       title,
-      fileName: fileName.replace(process.env.PWD, ''),
+      fileName: fileName.replace(process.cwd(), ''),
       // address,
       name: contractName,
       // only pass these if they are whitelisted
@@ -56,7 +56,7 @@ function compile({ whitelist, contracts, output, target, version }) {
   // TODO find in a better way?
   let pkgConfig = {};
   try {
-    pkgConfig = JSON.parse(fs.readFileSync(`${process.env.PWD}/package.json`));
+    pkgConfig = JSON.parse(fs.readFileSync(`${process.cwd()}/package.json`));
   } catch (e) {
     // console.log('package.json not found, add one for more output');
   }
@@ -73,7 +73,7 @@ function compile({ whitelist, contracts, output, target, version }) {
     buildTime: new Date(),
   };
 
-  const configFile = `${process.env.PWD}/${target}/${CONFIG_FILE}`;
+  const configFile = `${process.cwd()}/${target}/${CONFIG_FILE}`;
 
   try { // try marginging with old config
     config = { ...toml.parse(fs.readFileSync(configFile).toString()), ...config };
@@ -83,7 +83,7 @@ function compile({ whitelist, contracts, output, target, version }) {
   }
 
   try { // try marginging with doxity config
-    config = { ...config, ...JSON.parse(fs.readFileSync(`${process.env.PWD}/${DOXITYRC_FILE}`).toString()) };
+    config = { ...config, ...JSON.parse(fs.readFileSync(`${process.cwd()}/${DOXITYRC_FILE}`).toString()) };
   } catch (e) { /* do nothing */ }
 
   // write the config
@@ -92,8 +92,8 @@ function compile({ whitelist, contracts, output, target, version }) {
 
   // copy the readme
   try {
-    const readmeFile = glob.sync(`${process.env.PWD}/${README_FILE}`, { nocase: true })[0];
-    const readmeTarget = `${process.env.PWD}/${target}/${README_TARGET}`;
+    const readmeFile = glob.sync(`${process.cwd()}/${README_FILE}`, { nocase: true })[0];
+    const readmeTarget = `${process.cwd()}/${target}/${README_TARGET}`;
     if (fs.existsSync(readmeTarget)) { fs.unlinkSync(readmeTarget); }
     fs.writeFileSync(readmeTarget, fs.readFileSync(readmeFile));
   } catch (e) {
@@ -104,7 +104,11 @@ function compile({ whitelist, contracts, output, target, version }) {
 }
 
 export default function (opts) {
-  const output = `${process.env.PWD}/${opts.target}/${opts.dir}`;
+  if (!opts.dir)
+    opts.dir = DEFAULT_PAGES_DIR;
+  if (!opts.src)
+    opts.src = DEFAULT_SRC_DIR;
+  const output = `${process.cwd()}/${opts.target}/${opts.dir}`;
   if (!fs.existsSync(output)) { throw new Error(`Output directory ${output} not found, are you in the right directory?`); }
   // clear out the output folder (remove all json files)
   glob.sync(`${output}/*.json`).forEach(file => fs.unlinkSync(file));

--- a/src/compile/solc.js
+++ b/src/compile/solc.js
@@ -7,7 +7,7 @@ import compile from 'truffle-compile';
 export default function (src) {
   // detect if we're in a truffle project
   return new Promise((resolve) => {
-    if (fs.existsSync(`${process.env.PWD}/truffle.js`)) {
+    if (fs.existsSync(`${process.cwd()}/truffle.js`)) {
       const config = Config.default();
       config.resolver = new Resolver(config);
       config.rawData = true;
@@ -18,7 +18,7 @@ export default function (src) {
             const { metadata, ...rest } = res[k].rawData;
             const { output, settings } = JSON.parse(metadata);
             const fN = Object.keys(settings.compilationTarget)[0];
-            const fileName = fN.indexOf(process.env.PWD) === 0 ? fN : `${process.env.PWD}/node_modules/${fN}`;
+            const fileName = fN.indexOf(process.cwd()) === 0 ? fN : `${process.cwd()}/node_modules/${fN}`;
             return {
               ...o,
               [k]: { ...rest, ...output, fileName },
@@ -35,7 +35,7 @@ export default function (src) {
           const fileFragments = file.split('/');
           const contractName = fileFragments[fileFragments.length - 1].split('.sol')[0];
           const contract = res.contracts[k];
-          const fileName = `${process.env.PWD}/${k.split(':')[0]}`;
+          const fileName = `${process.cwd()}/${k.split(':')[0]}`;
           return {
             ...o,
             [contractName]: {

--- a/src/develop.js
+++ b/src/develop.js
@@ -2,7 +2,7 @@ import childProcess from 'child_process';
 
 export default function ({ target }) {
   // TODO check we're in ther right folder.. ?
-  const runDev = childProcess.spawn('npm', ['run', 'develop'], { cwd: `${process.env.PWD}/${target}` });
+  const runDev = childProcess.spawn('npm', ['run', 'develop'], { cwd: `${process.cwd()}/${target}` });
   runDev.stdout.pipe(process.stdout);
   runDev.stderr.pipe(process.stderr);
   runDev.on('close', () => process.exit());

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,3 +16,7 @@ export function clearDirectory(target) {
 export function getFunctionSignature(signature) {
   return new Keccak(256).update(signature).digest('hex').substr(0, 8);
 }
+
+export function getNpmCommandName() {
+  return /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+}

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function populateArguments(passed) {
   // merge with .doxityrc
   let saved = {};
   try {
-    saved = JSON.parse(fs.readFileSync(`${process.env.PWD}/${DOXITYRC_FILE}`).toString());
+    saved = JSON.parse(fs.readFileSync(`${process.cwd()}/${DOXITYRC_FILE}`).toString());
   } catch (e) {
     console.log('.doxityrc not found or unreadable');
   }

--- a/src/init.js
+++ b/src/init.js
@@ -4,15 +4,15 @@ import request from 'request';
 import path from 'path';
 import targz from 'tar.gz';
 
-import { clearDirectory } from './helpers';
+import { clearDirectory, getNpmCommandName } from './helpers';
 
 import { DOXITYRC_FILE } from './constants';
 
 export default function (args) {
   const { source, target } = args;
   // TODO check folder exists...
-  const absoluteTarget = `${process.env.PWD}/${target}`;
-  const tmpTarget = path.resolve(`${process.env.PWD}/${target}/../doxity-tmp-${new Date()}`);
+  const absoluteTarget = `${process.cwd()}/${target}`;
+  const tmpTarget = path.resolve(`${process.cwd()}/${target}/../doxity-tmp`);
   // clear the target dir
   clearDirectory(absoluteTarget)
   .then(() => {
@@ -41,14 +41,14 @@ export default function (args) {
       process.stdout.write(`\r${seq[i]} ${message}`);
     }, 1000 / 24);
     // install the deps
-    const npmInstall = childProcess.spawn('npm', ['install'], { cwd: absoluteTarget });
+    const npmInstall = childProcess.spawn(getNpmCommandName(), ['install'], { cwd: absoluteTarget });
     npmInstall.stdout.removeAllListeners('data');
     npmInstall.stderr.removeAllListeners('data');
     npmInstall.stdout.pipe(process.stdout);
     npmInstall.stderr.pipe(process.stderr);
     npmInstall.on('close', () => {
       clearInterval(spinner);
-      const doxityrcFile = `${process.env.PWD}/${DOXITYRC_FILE}`;
+      const doxityrcFile = `${process.cwd()}/${DOXITYRC_FILE}`;
       // overwrite doxityrc file
       if (fs.existsSync(doxityrcFile)) { fs.unlinkSync(doxityrcFile); }
       fs.writeFileSync(doxityrcFile, `${JSON.stringify(args, null, 2)}\n`);

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,15 +1,15 @@
 import fs from 'fs';
 import childProcess from 'child_process';
 
-import { clearDirectory } from './helpers';
+import { clearDirectory, getNpmCommandName } from './helpers';
 
 export default function ({ target, out }) {
   // TODO check folder exists...
-  const cwd = `${process.env.PWD}/${target}`;
+  const cwd = `${process.cwd()}/${target}`;
   const outputFolder = `${cwd}/public`;
-  const destFolder = `${process.env.PWD}/${out}`;
+  const destFolder = `${process.cwd()}/${out}`;
   clearDirectory(destFolder).then(() => {
-    const runDev = childProcess.spawn('npm', ['run', 'build'], { cwd });
+    const runDev = childProcess.spawn(getNpmCommandName(), ['run', 'build'], { cwd });
     runDev.stdout.pipe(process.stdout);
     runDev.stderr.pipe(process.stderr);
     runDev.on('close', () => {


### PR DESCRIPTION
I don't have a linux machine so can't verify that I didn't break the pipeline on linux.

build command still fails when executing solc - I'm not sure if it can receive wildcard as file input on linux, but on windows it doesn't seem like it can.
Possible solution is to pass the entire file list to solc.