### PR TITLE
Towards fixing windows compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 npm-debug.log
+node_modules/*
+scripts/*

--- a/doxity
+++ b/doxity
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/lib/bin/doxity.js" "$@"
+  ret=$?
+else
+  node  "$basedir/lib/bin/doxity.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/doxity.cmd
+++ b/doxity.cmd
@@ -1,0 +1,9 @@
+@SET PWD=%~dp0
+
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe" "%PWD%\lib\bin\doxity.js" %*
+) ELSE (
+  @SETLOCAL
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node "%PWD%\lib\bin\doxity.js" %*
+)

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; /* eslint-disable global-require */
 
 exports.default = function (opts) {
-  var output = process.env.PWD + '/' + opts.target + '/' + opts.dir;
+  var output = _path2.default.join(process.env.PWD, opts.target, opts.dir);
   if (!_fs2.default.existsSync(output)) {
     throw new Error('Output directory ' + output + ' not found, are you in the right directory?');
   }
@@ -26,6 +26,10 @@ exports.default = function (opts) {
 var _fs = require('fs');
 
 var _fs2 = _interopRequireDefault(_fs);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
 
 var _glob = require('glob');
 

--- a/lib/compile/solc.js
+++ b/lib/compile/solc.js
@@ -7,6 +7,48 @@ Object.defineProperty(exports, "__esModule", {
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 exports.default = function (src) {
+  function expandPath(src) {
+    if (!pathEndsWithWildcard(src)) {
+      return src;
+    }
+
+    var basePath = removeLastCharacter(src);
+    var files = traverseDir(basePath, []);
+    return files.join(" ");
+  };
+
+  function pathEndsWithWildcard(path) {
+    return path[path.length - 1] === "*";
+  };
+
+  function removeLastCharacter(text) {
+    return text.substring(0, text.length - 1);
+  };
+
+  function traverseDir(dir, files) {
+    files = files || [];
+    var dirContents = _fs2.default.readdirSync(dir);
+    dirContents.forEach(function (dirEntry) {
+      var fileName = _path2.default.join(dir, dirEntry);
+      if (_fs2.default.statSync(fileName).isDirectory()) {
+        files = traverseDir(fileName, files);
+      } else {
+        files.push(fileName);
+      }
+    });
+    return files;
+  };
+
+  function extractFilenameFromContract(contractKey) {
+    var separatorPosition = contractKey.lastIndexOf(":");
+    return contractKey.substring(0, separatorPosition);
+  };
+
+  function extractNameFromContract(contractKey) {
+    var separatorPosition = contractKey.lastIndexOf(":");
+    return contractKey.substring(separatorPosition + 1);
+  };
+
   // detect if we're in a truffle project
   return new Promise(function (resolve) {
     if (_fs2.default.existsSync(process.env.PWD + '/truffle.js')) {
@@ -36,15 +78,18 @@ exports.default = function (src) {
         });
       });
     } else {
-      var exec = 'solc --combined-json abi,asm,ast,bin,bin-runtime,clone-bin,devdoc,interface,opcodes,srcmap,srcmap-runtime,userdoc ' + src;
+      var exec = 'solc --combined-json abi,asm,ast,bin,bin-runtime,clone-bin,devdoc,interface,opcodes,srcmap,srcmap-runtime,userdoc ' + expandPath(src);
       var res = JSON.parse(_child_process2.default.execSync(exec));
       resolve({
         contracts: Object.keys(res.contracts).reduce(function (o, k) {
-          var file = k.split(':')[0];
-          var fileFragments = file.split('/');
-          var contractName = fileFragments[fileFragments.length - 1].split('.sol')[0];
           var contract = res.contracts[k];
-          var fileName = process.env.PWD + '/' + k.split(':')[0];
+          var fileName = extractFilenameFromContract(k);
+          var contractName = extractNameFromContract(k);
+
+          if (!_path2.default.isAbsolute(fileName)) {
+            fileName = _path2.default.join(process.env.PWD, fileName);
+          }
+
           return _extends({}, o, _defineProperty({}, contractName, _extends({}, contract, {
             fileName: fileName,
             abi: JSON.parse(contract.abi),
@@ -60,6 +105,10 @@ exports.default = function (src) {
 var _fs = require('fs');
 
 var _fs2 = _interopRequireDefault(_fs);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
 
 var _child_process = require('child_process');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,10 @@ var _fs = require('fs');
 
 var _fs2 = _interopRequireDefault(_fs);
 
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
 var _constants = require('./constants');
 
 var _init = require('./init');
@@ -55,10 +59,11 @@ function populateArguments(passed) {
   };
   // merge with .doxityrc
   var saved = {};
+  var configFilePath = _path2.default.join(process.env.PWD, _constants.DOXITYRC_FILE);
   try {
-    saved = JSON.parse(_fs2.default.readFileSync(process.env.PWD + '/' + _constants.DOXITYRC_FILE).toString());
+    saved = JSON.parse(_fs2.default.readFileSync(configFilePath).toString());
   } catch (e) {
-    console.log('.doxityrc not found or unreadable');
+    console.log('.doxityrc not found or unreadable. Searched in %s', configFilePath);
   }
   // return merge
   return _extends({}, defaults, saved, passed);

--- a/lib/init.js
+++ b/lib/init.js
@@ -9,8 +9,30 @@ exports.default = function (args) {
       target = args.target;
   // TODO check folder exists...
 
-  var absoluteTarget = process.env.PWD + '/' + target;
-  var tmpTarget = _path2.default.resolve(process.env.PWD + '/' + target + '/../doxity-tmp-' + new Date());
+  function isWindows() {
+    return process.platform === "win32";
+  };
+
+  function addLeadingZeroIfNeeded(value) {
+    if (value < 10) {
+      return "0" + value;
+    } else {
+      return "" + value;
+    }
+  };
+
+  var absoluteTarget = _path2.default.join(process.env.PWD, target);
+
+  var now = new Date();
+  var year = now.getUTCFullYear();
+  var month = addLeadingZeroIfNeeded(now.getUTCMonth());
+  var day = addLeadingZeroIfNeeded(now.getUTCDate());
+  var hours = addLeadingZeroIfNeeded(now.getUTCHours());
+  var minutes = addLeadingZeroIfNeeded(now.getUTCMinutes());
+  var seconds = addLeadingZeroIfNeeded(now.getUTCSeconds());
+  var timestamp = '' + year + month + day + hours + minutes + seconds;
+
+  var tmpTarget = _path2.default.resolve(_path2.default.join(process.env.PWD, target, '/../doxity-tmp-' + timestamp));
   // clear the target dir
   (0, _helpers.clearDirectory)(absoluteTarget).then(function () {
     // clone the repo
@@ -22,7 +44,8 @@ exports.default = function (args) {
   })
   // rename the downloaded folder to doxity
   .then(function () {
-    _fs2.default.renameSync(tmpTarget + '/' + _fs2.default.readdirSync(tmpTarget)[0], absoluteTarget);
+    var tempTargetFilename = _path2.default.join(tmpTarget, _fs2.default.readdirSync(tmpTarget)[0]);
+    _fs2.default.renameSync(tempTargetFilename, absoluteTarget);
     _fs2.default.rmdirSync(tmpTarget);
   }).then(function () {
     // fancy spinner
@@ -37,14 +60,16 @@ exports.default = function (args) {
       process.stdout.write('\r' + seq[i] + ' ' + message);
     }, 1000 / 24);
     // install the deps
-    var npmInstall = _child_process2.default.spawn('npm', ['install'], { cwd: absoluteTarget });
+    var npmCommand = isWindows() ? "npm.cmd" : "npm";
+    var npmInstall = _child_process2.default.spawn(npmCommand, ['install'], { cwd: absoluteTarget });
+
     npmInstall.stdout.removeAllListeners('data');
     npmInstall.stderr.removeAllListeners('data');
     npmInstall.stdout.pipe(process.stdout);
     npmInstall.stderr.pipe(process.stderr);
     npmInstall.on('close', function () {
       clearInterval(spinner);
-      var doxityrcFile = process.env.PWD + '/' + _constants.DOXITYRC_FILE;
+      var doxityrcFile = _path2.default.join(process.env.PWD, _constants.DOXITYRC_FILE);
       // overwrite doxityrc file
       if (_fs2.default.existsSync(doxityrcFile)) {
         _fs2.default.unlinkSync(doxityrcFile);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -8,12 +8,17 @@ exports.default = function (_ref) {
   var target = _ref.target,
       out = _ref.out;
 
+  function isWindows() {
+    return process.platform === "win32";
+  };
+
   // TODO check folder exists...
-  var cwd = process.env.PWD + '/' + target;
-  var outputFolder = cwd + '/public';
-  var destFolder = process.env.PWD + '/' + out;
+  var cwd = _path2.default.join(process.env.PWD, target);
+  var outputFolder = _path2.default.join(cwd, '/public');
+  var destFolder = _path2.default.join(process.env.PWD, out);
   (0, _helpers.clearDirectory)(destFolder).then(function () {
-    var runDev = _child_process2.default.spawn('npm', ['run', 'build'], { cwd: cwd });
+    var npmCommand = isWindows() ? "npm.cmd" : "npm";
+    var runDev = _child_process2.default.spawn(npmCommand, ['run', 'build'], { cwd: cwd });
     runDev.stdout.pipe(process.stdout);
     runDev.stderr.pipe(process.stderr);
     runDev.on('close', function () {
@@ -27,6 +32,10 @@ exports.default = function (_ref) {
 var _fs = require('fs');
 
 var _fs2 = _interopRequireDefault(_fs);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
 
 var _child_process = require('child_process');
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "./node_modules/.bin/mocha --watch --compilers js:babel-register",
     "test": "./node_modules/.bin/mocha --compilers js:babel-register",
-    "compile": "rm -rf lib/* && ./node_modules/.bin/babel src -d lib && chmod +x ./lib/bin/doxity.js",
+    "compile": "rmdir /q /s lib & node_modules\\.bin\\babel src -d lib ",
     "prepublish": "npm run compile"
   },
   "bin": {

--- a/src/compile/index.js
+++ b/src/compile/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 
 import fs from 'fs';
+import path from 'path';
 import glob from 'glob';
 import toml from 'toml';
 import tomlify from 'tomlify-j0.4';
@@ -105,7 +106,7 @@ function compile({ whitelist, contracts, output, target, version }) {
 }
 
 export default function (opts) {
-  const output = `${process.env.PWD}/${opts.target}/${opts.dir}`;
+  const output = path.join(process.env.PWD, opts.target, opts.dir);
   if (!fs.existsSync(output)) { throw new Error(`Output directory ${output} not found, are you in the right directory?`); }
   // clear out the output folder (remove all json files)
   glob.sync(`${output}/*.json`).forEach(file => fs.unlinkSync(file));

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 import {
   DOXITYRC_FILE,
@@ -36,10 +37,11 @@ function populateArguments(passed) {
   };
   // merge with .doxityrc
   let saved = {};
+  let configFilePath = path.join(process.env.PWD, DOXITYRC_FILE);
   try {
-    saved = JSON.parse(fs.readFileSync(`${process.env.PWD}/${DOXITYRC_FILE}`).toString());
+    saved = JSON.parse(fs.readFileSync(configFilePath).toString());
   } catch (e) {
-    console.log('.doxityrc not found or unreadable');
+    console.log('.doxityrc not found or unreadable. Searched in %s', configFilePath);
   }
   // return merge
   return { ...defaults, ...saved, ...passed };

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,15 +1,21 @@
 import fs from 'fs';
+import path from 'path';
 import childProcess from 'child_process';
 
 import { clearDirectory } from './helpers';
 
 export default function ({ target, out }) {
+  function isWindows() {
+      return process.platform === "win32";
+  };
+
   // TODO check folder exists...
-  const cwd = `${process.env.PWD}/${target}`;
-  const outputFolder = `${cwd}/public`;
-  const destFolder = `${process.env.PWD}/${out}`;
+  const cwd = path.join(process.env.PWD, target);
+  const outputFolder = path.join(cwd, '/public');
+  const destFolder = path.join(process.env.PWD, out);
   clearDirectory(destFolder).then(() => {
-    const runDev = childProcess.spawn('npm', ['run', 'build'], { cwd });
+    var npmCommand = isWindows() ? "npm.cmd" : "npm";
+    var runDev = childProcess.spawn(npmCommand, ['run', 'build'], { cwd: cwd });
     runDev.stdout.pipe(process.stdout);
     runDev.stderr.pipe(process.stderr);
     runDev.on('close', () => {


### PR DESCRIPTION
- replaced path concatenation with "path.join", as this works in all platforms.
- added logic to detect the current platform, and run npm or npm.cmd as appropriate. This is needed to properly install gatsby in init.js, and run its build command in publish.js.
- added logic to expand a final wildcard * into a list of all the files under that path. In my tests, passing a specific contract only generated the documentation for the contracts "pulled" by that one.
- in init.js,  changed the name of the downloaded gatsby tar.gz file to not have any whitespaces, because these were causing problems to me
- added a doxity.cmd file that sets the PWD environment variable, so that doxity can find it when looking for process.env.PWD.
- changed the compile target in package.json to commands that work on Windows (exclusively). It would be better to have a solution that worked in all platforms.