### PR TITLE
Fix homepage and github links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "author": "Chris Hitchcott <hitchcott@gmail.com> (http://hitchcott.com)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/DigixGlobal/doxidity.git"
+    "url": "https://github.com/DigixGlobal/doxity.git"
   },
-  "homepage": "https://github.com/DigixGlobal/doxidity",
+  "homepage": "https://github.com/DigixGlobal/doxity",
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.16.0",


### PR DESCRIPTION
These used to point to nonexistent urls